### PR TITLE
🎨 Palette: Improve accessibility and keyboard support for Contact buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - Accessible Reveal Patterns
+**Learning:** The "reveal on hover" pattern for contact details (common in academic sites) is inaccessible to keyboard and screen reader users. Simply adding focus event listeners is not enough if the screen reader doesn't know the text has changed.
+**Action:** Always pair focus-based reveals with aria-live="polite" and descriptive aria-labels to ensure keyboard parity and screen reader awareness.

--- a/Omeka Front End/landing_page/Research Team.html
+++ b/Omeka Front End/landing_page/Research Team.html
@@ -154,7 +154,8 @@
         }
 
         /* Hover Effect: Show Email - faster expand on enter */
-        .contact-btn:hover {
+        .contact-btn:hover,
+        .contact-btn:focus-visible {
             min-width: 220px;
             background: var(--color-text-primary);
             color: white;
@@ -484,18 +485,28 @@
                     }, 150); // Match CSS transition timing
                 }
 
-                // Hover effect: Show email
-                btn.addEventListener('mouseenter', () => {
+                // Accessibility: Set descriptive aria-label and live region
+                const memberName = btn.closest('.member-card').querySelector('.member-name').textContent.trim();
+                btn.setAttribute('aria-label', `Contact ${memberName}`);
+                textSpan.setAttribute('aria-live', 'polite');
+
+                // Hover and Focus effect: Show email
+                const showEmail = () => {
                     if (!btn.classList.contains('copied') && !isLocked) {
                         updateText(email);
                     }
-                });
+                };
 
-                btn.addEventListener('mouseleave', () => {
+                const hideEmail = () => {
                     if (!btn.classList.contains('copied') && !isLocked) {
                         updateText(originalText);
                     }
-                });
+                };
+
+                btn.addEventListener('mouseenter', showEmail);
+                btn.addEventListener('focus', showEmail);
+                btn.addEventListener('mouseleave', hideEmail);
+                btn.addEventListener('blur', hideEmail);
 
                 // Click effect: Copy to clipboard
                 btn.addEventListener('click', async (e) => {


### PR DESCRIPTION
This PR improves the accessibility and keyboard support of the "Contact" buttons on the Research Team page. 

Changes:
- Added `:focus-visible` styles to match hover expansion effect.
- Added `focus` and `blur` event listeners to reveal/hide email addresses for keyboard users.
- Added `aria-live="polite"` to revealed text for screen reader announcements.
- Programmatically assigned descriptive `aria-label` attributes (e.g., "Contact [Name]") to each button.
- Cleaned up formatting and ensured the change is under 50 lines.

---
*PR created automatically by Jules for task [10180415720593348714](https://jules.google.com/task/10180415720593348714) started by @articoder*