### PR TITLE
🎨 Palette: Improved Contact Button Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - [Accessible Reveal Patterns]
+**Learning:** Interactive reveal patterns (like showing an email on hover) are often inaccessible to keyboard and screen reader users. To fix this, use :focus-visible for visual reveal and dynamic aria-label updates combined with aria-live regions for screen reader feedback.
+**Action:** Always ensure hover-based reveal effects are mirrored with focus-based listeners and provide explicit screen reader announcements for the revealed content.

--- a/Omeka Front End/landing_page/Research Team.html
+++ b/Omeka Front End/landing_page/Research Team.html
@@ -153,8 +153,8 @@
             transition: opacity 0.15s ease, transform 0.15s ease;
         }
 
-        /* Hover Effect: Show Email - faster expand on enter */
-        .contact-btn:hover {
+        /* Hover/Focus Effect: Show Email - faster expand on enter */
+        .contact-btn:hover, .contact-btn:focus-visible {
             min-width: 220px;
             background: var(--color-text-primary);
             color: white;
@@ -467,9 +467,18 @@
 
             contactBtns.forEach(btn => {
                 const textSpan = btn.querySelector('span');
+                if (!textSpan) return;
+
                 const originalText = "Contact";
                 const email = btn.getAttribute('data-email');
+                const memberCard = btn.closest('.member-card');
+                const nameEl = memberCard ? memberCard.querySelector('.member-name') : null;
+                const memberName = nameEl ? nameEl.textContent.trim().replace(/\s+/g, ' ') : "Team Member";
+
                 let isLocked = false; // Prevent interactions during cooldown
+
+                // Initial accessibility
+                btn.setAttribute('aria-label', `Contact ${memberName} via email`);
 
                 // Helper to change text smoothly
                 function updateText(newText, callback) {
@@ -484,18 +493,23 @@
                     }, 150); // Match CSS transition timing
                 }
 
-                // Hover effect: Show email
-                btn.addEventListener('mouseenter', () => {
+                // Hover/Focus effect: Show email
+                const showEmail = () => {
                     if (!btn.classList.contains('copied') && !isLocked) {
                         updateText(email);
                     }
-                });
+                };
 
-                btn.addEventListener('mouseleave', () => {
+                const hideEmail = () => {
                     if (!btn.classList.contains('copied') && !isLocked) {
                         updateText(originalText);
                     }
-                });
+                };
+
+                btn.addEventListener('mouseenter', showEmail);
+                btn.addEventListener('focus', showEmail);
+                btn.addEventListener('mouseleave', hideEmail);
+                btn.addEventListener('blur', hideEmail);
 
                 // Click effect: Copy to clipboard
                 btn.addEventListener('click', async (e) => {
@@ -513,15 +527,17 @@
                         // Show feedback
                         updateText("Copied Email Address");
                         btn.classList.add('copied');
+                        btn.setAttribute('aria-label', `Email address for ${memberName} copied to clipboard`);
 
                         // Reset after 2 seconds
                         setTimeout(() => {
-                            // Determine target state based on hover
-                            const isHovering = btn.matches(':hover');
-                            const targetText = isHovering ? email : originalText;
+                            // Determine target state based on hover/focus
+                            const isActive = btn.matches(':hover') || btn.matches(':focus-visible');
+                            const targetText = isActive ? email : originalText;
 
                             // Remove copied class first to start width transition
                             btn.classList.remove('copied');
+                            btn.setAttribute('aria-label', `Contact ${memberName} via email`);
 
                             // Update text with slight delay to ensure smooth visual
                             setTimeout(() => {


### PR DESCRIPTION
This PR improves the accessibility and UX of the "Contact" buttons on the Research Team page. 

Previously, the buttons only revealed the email address and provided "Copied" feedback on mouse hover and click. This change ensures that:
1. Keyboard users can focus the buttons to see the email address expansion.
2. Screen reader users receive descriptive labels ("Contact [Name] via email") instead of just "Contact".
3. Screen reader users receive immediate feedback when the email is copied to the clipboard.

The implementation uses dynamic ARIA label updates and mirrors hover behavior with focus/blur listeners. It also includes defensive coding with null checks to ensure stability.

---
*PR created automatically by Jules for task [16732891551915436820](https://jules.google.com/task/16732891551915436820) started by @articoder*