### PR TITLE
🎨 Palette: Accessible email reveal & focus polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-09 - Accessible Interactive Reveal Patterns
+**Learning:** When implementing interactive 'reveal' patterns (e.g., showing emails or text on hover), keyboard users are often neglected. Using focus/blur listeners in addition to mouseenter/mouseleave, and providing dynamic aria-label updates instead of just visual text changes, ensures the feature is accessible to all users. Also, textContent from HTML should be sanitized of extra whitespace/newlines when used in ARIA labels.
+**Action:** Always pair hover-based reveal logic with focus/blur listeners, and sanitize extracted text using .trim().replace(/\s+/g, ' ') for use in ARIA attributes.

--- a/Omeka Front End/landing_page/Research Team.html
+++ b/Omeka Front End/landing_page/Research Team.html
@@ -180,6 +180,20 @@
                 border-color 0.25s ease;
         }
 
+        /* Focus States */
+        .contact-btn:focus-visible {
+            outline: 2px solid var(--color-accent-coral);
+            outline-offset: 4px;
+            box-shadow: 0 0 0 2px white, 0 0 0 4px var(--color-accent-coral);
+        }
+
+        .member-name:focus-visible {
+            outline: 2px solid var(--color-accent-coral);
+            outline-offset: 4px;
+            color: var(--color-accent-coral);
+            border-radius: 4px;
+        }
+
         /* Section dividers */
         .section-title {
             position: relative;
@@ -469,7 +483,12 @@
                 const textSpan = btn.querySelector('span');
                 const originalText = "Contact";
                 const email = btn.getAttribute('data-email');
+                const memberCard = btn.closest('.member-card');
+                const memberName = memberCard ? memberCard.querySelector('.member-name').textContent.trim().replace(/\s+/g, ' ') : "Researcher";
                 let isLocked = false; // Prevent interactions during cooldown
+
+                // Initial ARIA setup
+                btn.setAttribute('aria-label', `Contact ${memberName} (copies email to clipboard)`);
 
                 // Helper to change text smoothly
                 function updateText(newText, callback) {
@@ -484,18 +503,24 @@
                     }, 150); // Match CSS transition timing
                 }
 
-                // Hover effect: Show email
-                btn.addEventListener('mouseenter', () => {
+                // Show email on hover/focus
+                const showEmail = () => {
                     if (!btn.classList.contains('copied') && !isLocked) {
                         updateText(email);
                     }
-                });
+                };
 
-                btn.addEventListener('mouseleave', () => {
+                // Hide email on leave/blur
+                const hideEmail = () => {
                     if (!btn.classList.contains('copied') && !isLocked) {
                         updateText(originalText);
                     }
-                });
+                };
+
+                btn.addEventListener('mouseenter', showEmail);
+                btn.addEventListener('focus', showEmail);
+                btn.addEventListener('mouseleave', hideEmail);
+                btn.addEventListener('blur', hideEmail);
 
                 // Click effect: Copy to clipboard
                 btn.addEventListener('click', async (e) => {
@@ -513,15 +538,17 @@
                         // Show feedback
                         updateText("Copied Email Address");
                         btn.classList.add('copied');
+                        btn.setAttribute('aria-label', `Email for ${memberName} copied to clipboard`);
 
                         // Reset after 2 seconds
                         setTimeout(() => {
-                            // Determine target state based on hover
-                            const isHovering = btn.matches(':hover');
-                            const targetText = isHovering ? email : originalText;
+                            // Determine target state based on hover or focus
+                            const isInteracting = btn.matches(':hover') || btn.matches(':focus');
+                            const targetText = isInteracting ? email : originalText;
 
                             // Remove copied class first to start width transition
                             btn.classList.remove('copied');
+                            btn.setAttribute('aria-label', `Contact ${memberName} (copies email to clipboard)`);
 
                             // Update text with slight delay to ensure smooth visual
                             setTimeout(() => {


### PR DESCRIPTION
This PR improves the accessibility and UX of the Research Team page by making the "Contact" button's email reveal feature accessible to keyboard users. It also adds clear focus indicators and descriptive ARIA labels for better screen reader support.

---
*PR created automatically by Jules for task [7451600408851325081](https://jules.google.com/task/7451600408851325081) started by @articoder*